### PR TITLE
Add Data & statistik page with charts and Swedishness matrix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import Home from './pages/Home';
 import About from './pages/About';
+import Data from './pages/Data';
 import AddBrandForm from './components/AddBrandForm';
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
         <Header onAddBrand={() => setShowAddForm(true)} />
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/data" element={<Data />} />
           <Route path="/om" element={<About />} />
         </Routes>
         <Footer />

--- a/src/components/CountryBars.tsx
+++ b/src/components/CountryBars.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import Flag from './Flag';
+
+export interface CountryBar {
+  /** ISO 3166-1 alpha-2 code for the flag. Omit for aggregate/region bars. */
+  code?: string;
+  label: string;
+  count: number;
+}
+
+interface CountryBarsProps {
+  /** Bars in display order (already sorted). */
+  items: CountryBar[];
+  caption?: ReactNode;
+  emptyMessage?: string;
+}
+
+export default function CountryBars({
+  items,
+  caption,
+  emptyMessage = 'Ingen data att visa.',
+}: CountryBarsProps) {
+  if (items.length === 0) {
+    return <p className="ownership-empty">{emptyMessage}</p>;
+  }
+
+  const maxCount = Math.max(...items.map((i) => i.count));
+
+  return (
+    <div className="country-bars">
+      <ul className="country-list">
+        {items.map((item) => (
+          <li key={item.label} className="country-row">
+            <span className="country-name" title={item.label}>
+              {item.code ? (
+                <Flag countryCode={item.code} />
+              ) : (
+                <span className="country-flag-placeholder" aria-hidden="true" />
+              )}
+              <span className="country-name-text">{item.label}</span>
+            </span>
+            <div className="country-track">
+              <div
+                className="country-fill"
+                style={{ width: `${(item.count / maxCount) * 100}%` }}
+              >
+                <span className="country-count">{item.count}</span>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {caption && <p className="ownership-caption">{caption}</p>}
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,6 +16,9 @@ export default function Header({ onAddBrand }: HeaderProps) {
             <button className="add-brand-btn header-add-btn" onClick={onAddBrand} type="button">
               + Föreslå märke
             </button>
+            <Link to="/data" className="add-brand-btn header-add-btn secondary-btn">
+              Data
+            </Link>
             <Link to="/om" className="add-brand-btn header-add-btn secondary-btn">
               Om
             </Link>

--- a/src/components/OwnershipBars.tsx
+++ b/src/components/OwnershipBars.tsx
@@ -1,0 +1,44 @@
+export interface OwnerCount {
+  owner: string;
+  count: number;
+}
+
+interface OwnershipBarsProps {
+  /** Owners controlling >= 2 brands, already sorted by count descending. */
+  owners: OwnerCount[];
+  /** Total number of brands in the database, for the reconciliation caption. */
+  total: number;
+}
+
+export default function OwnershipBars({ owners, total }: OwnershipBarsProps) {
+  if (owners.length === 0) {
+    return <p className="ownership-empty">Inga moderbolag med fler än ett varumärke i databasen.</p>;
+  }
+
+  const maxCount = owners[0].count;
+  const shown = owners.reduce((sum, o) => sum + o.count, 0);
+  const rest = total - shown;
+
+  return (
+    <div className="ownership-bars">
+      <ul className="ownership-list">
+        {owners.map((o) => (
+          <li key={o.owner} className="ownership-row">
+            <span className="ownership-name" title={o.owner}>
+              {o.owner}
+            </span>
+            <div className="ownership-track">
+              <div className="ownership-fill" style={{ width: `${(o.count / maxCount) * 100}%` }}>
+                <span className="ownership-count">{o.count}</span>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p className="ownership-caption">
+        De {owners.length} största moderbolagen äger {shown} av {total} varumärken. Övriga {rest}{' '}
+        ägs oberoende eller tillhör ett bolag med bara ett varumärke i databasen.
+      </p>
+    </div>
+  );
+}

--- a/src/components/StatusDonut.tsx
+++ b/src/components/StatusDonut.tsx
@@ -1,0 +1,83 @@
+interface StatusCounts {
+  Ja: number;
+  Delvis: number;
+  Nej: number;
+}
+
+interface StatusDonutProps {
+  counts: StatusCounts;
+  total: number;
+}
+
+// Order + colors reuse the site's reserved status palette (see .status-badge in index.css).
+const SEGMENTS = [
+  { key: 'Ja', label: 'Ja', fill: '#99dec9' },
+  { key: 'Delvis', label: 'Delvis', fill: '#99D5ED' },
+  { key: 'Nej', label: 'Nej', fill: '#edb0ab' },
+] as const;
+
+export default function StatusDonut({ counts, total }: StatusDonutProps) {
+  const size = 240;
+  const strokeWidth = 34;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const gap = 2; // px of surface showing between segments
+
+  // Accumulated fraction (0..1) used to rotate each segment to its start angle.
+  let cumulative = 0;
+
+  return (
+    <div className="status-donut">
+      <div className="status-donut-figure">
+        <svg
+          viewBox={`0 0 ${size} ${size}`}
+          className="status-donut-svg"
+          role="img"
+          aria-label={`Tillverkad i Sverige: ${counts.Ja} Ja, ${counts.Delvis} Delvis, ${counts.Nej} Nej av totalt ${total} varumärken.`}
+        >
+          {SEGMENTS.map((seg) => {
+            const value = counts[seg.key];
+            if (total <= 0 || value <= 0) return null;
+            const fraction = value / total;
+            const dash = Math.max(fraction * circumference - gap, 0.5);
+            const rotation = cumulative * 360 - 90; // -90 => start at 12 o'clock
+            cumulative += fraction;
+            return (
+              <circle
+                key={seg.key}
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                fill="none"
+                stroke={seg.fill}
+                strokeWidth={strokeWidth}
+                strokeDasharray={`${dash} ${circumference}`}
+                transform={`rotate(${rotation} ${size / 2} ${size / 2})`}
+              />
+            );
+          })}
+        </svg>
+        <div className="status-donut-center">
+          <span className="status-donut-total">{total}</span>
+          <span className="status-donut-total-label">varumärken</span>
+        </div>
+      </div>
+
+      <ul className="status-donut-legend">
+        {SEGMENTS.map((seg) => {
+          const value = counts[seg.key];
+          const pct = total > 0 ? Math.round((value / total) * 100) : 0;
+          return (
+            <li key={seg.key} className="status-donut-legend-item">
+              <span className="status-donut-swatch" style={{ backgroundColor: seg.fill }} />
+              <span className="status-donut-legend-label">{seg.label}</span>
+              <span className="status-donut-legend-value">
+                {value} <span className="status-donut-legend-pct">· {pct}%</span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/SwedishnessMatrix.tsx
+++ b/src/components/SwedishnessMatrix.tsx
@@ -1,0 +1,192 @@
+import { useMemo } from 'react';
+import Flag from './Flag';
+import { Brand } from '../types/brand';
+
+interface SwedishnessMatrixProps {
+  brands: Brand[];
+}
+
+type OwnerBucket = 'swedish' | 'foreign';
+type Status = 'Ja' | 'Delvis' | 'Nej';
+
+// Columns reuse the site's reserved status palette (see .status-badge in index.css).
+// `rgb` drives the heatmap tint; `text` keeps the count readable at any opacity.
+const COLUMNS: { key: Status; label: string; rgb: string; text: string }[] = [
+  { key: 'Ja', label: 'Ja', rgb: '153, 222, 201', text: '#004530' },
+  { key: 'Delvis', label: 'Delvis', rgb: '153, 213, 237', text: '#005D7F' },
+  { key: 'Nej', label: 'Nej', rgb: '237, 176, 171', text: '#7e211a' },
+];
+
+const ROWS: { key: OwnerBucket; label: string }[] = [
+  { key: 'swedish', label: 'Svenskägt' },
+  { key: 'foreign', label: 'Utländskt ägt' },
+];
+
+const compareSwedish = (a: string, b: string): number =>
+  a.localeCompare(b, 'sv-SE', { sensitivity: 'base' });
+
+/**
+ * Classify a brand by owner nationality. Mirrors the source GROQ logic:
+ * a brand with no corporate group (independent) or a Swedish ultimate owner
+ * counts as Swedish-owned; anything with a foreign or unknown owner country
+ * counts as foreign-owned.
+ */
+function ownerBucket(brand: Brand): OwnerBucket {
+  const ks = brand.merInfo.koncernstruktur;
+  if (typeof ks === 'string' || !ks) return 'swedish'; // legacy / independent
+  const hasKoncern = Boolean(ks.ägare || ks.moderbolag || ks.ägareLand);
+  if (!hasKoncern) return 'swedish';
+  const land = ks.ägareLand?.trim().toUpperCase();
+  return land === 'SE' ? 'swedish' : 'foreign';
+}
+
+const MAX_ABROAD_CHIPS = 12;
+
+export default function SwedishnessMatrix({ brands }: SwedishnessMatrixProps) {
+  const data = useMemo(() => {
+    const counts: Record<OwnerBucket, Record<Status, number>> = {
+      swedish: { Ja: 0, Delvis: 0, Nej: 0 },
+      foreign: { Ja: 0, Delvis: 0, Nej: 0 },
+    };
+
+    for (const brand of brands) {
+      counts[ownerBucket(brand)][brand.tillverkadISverige] += 1;
+    }
+
+    const cellValues = ROWS.flatMap((r) => COLUMNS.map((c) => counts[r.key][c.key]));
+    const maxCell = Math.max(1, ...cellValues);
+
+    // The two surprise quadrants that make the story.
+    const swedishAbroad = brands
+      .filter((b) => ownerBucket(b) === 'swedish' && b.tillverkadISverige === 'Nej')
+      .map((b) => b.varumärke)
+      .sort(compareSwedish);
+
+    const foreignHere = brands
+      .filter((b) => ownerBucket(b) === 'foreign' && b.tillverkadISverige === 'Ja')
+      .map((b) => {
+        const ks = b.merInfo.koncernstruktur;
+        const owner = typeof ks === 'string' ? '' : ks?.ägare ?? '';
+        const ownerLand = typeof ks === 'string' ? '' : ks?.ägareLand ?? '';
+        return { namn: b.varumärke, owner, ownerLand };
+      })
+      .sort((a, b) => compareSwedish(a.namn, b.namn));
+
+    return { counts, maxCell, swedishAbroad, foreignHere };
+  }, [brands]);
+
+  const { counts, maxCell, swedishAbroad, foreignHere } = data;
+
+  const rowTotal = (row: OwnerBucket) =>
+    COLUMNS.reduce((sum, c) => sum + counts[row][c.key], 0);
+  const colTotal = (col: Status) =>
+    ROWS.reduce((sum, r) => sum + counts[r.key][col], 0);
+  const grandTotal = ROWS.reduce((sum, r) => sum + rowTotal(r.key), 0);
+
+  const shownAbroad = swedishAbroad.slice(0, MAX_ABROAD_CHIPS);
+  const restAbroad = swedishAbroad.length - shownAbroad.length;
+
+  return (
+    <div className="matrix">
+      <div className="matrix-table-wrap">
+        <table
+          className="matrix-table"
+          aria-label="Antal varumärken efter ägarnationalitet och tillverkning i Sverige"
+        >
+          <thead>
+            <tr>
+              <th scope="col" rowSpan={2} className="matrix-stub">
+                Ägare
+              </th>
+              <th scope="colgroup" colSpan={3} className="matrix-grouphead">
+                Tillverkad i Sverige
+              </th>
+              <th scope="col" rowSpan={2} className="matrix-colhead matrix-total-head">
+                Totalt
+              </th>
+            </tr>
+            <tr>
+              {COLUMNS.map((c) => (
+                <th key={c.key} scope="col" className="matrix-colhead">
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((r) => (
+              <tr key={r.key}>
+                <th scope="row" className="matrix-rowhead">
+                  {r.label}
+                </th>
+                {COLUMNS.map((c) => {
+                  const value = counts[r.key][c.key];
+                  const alpha = 0.15 + 0.85 * (value / maxCell);
+                  return (
+                    <td
+                      key={c.key}
+                      className="matrix-cell"
+                      style={{ backgroundColor: `rgba(${c.rgb}, ${alpha})`, color: c.text }}
+                    >
+                      <span className="matrix-count">{value}</span>
+                    </td>
+                  );
+                })}
+                <td className="matrix-cell matrix-total">{rowTotal(r.key)}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr>
+              <th scope="row" className="matrix-rowhead">
+                Totalt
+              </th>
+              {COLUMNS.map((c) => (
+                <td key={c.key} className="matrix-cell matrix-total">
+                  {colTotal(c.key)}
+                </td>
+              ))}
+              <td className="matrix-cell matrix-total matrix-grand">{grandTotal}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <div className="matrix-highlights">
+        <div className="matrix-card">
+          <h3 className="matrix-card-title">Svenskägt, ändå tillverkat utomlands</h3>
+          <p className="matrix-card-text">
+            {swedishAbroad.length} svenskägda varumärken tillverkas inte i Sverige. Många av dem
+            uppfattas nog som svensktillverkade:
+          </p>
+          <ul className="matrix-chips">
+            {shownAbroad.map((namn) => (
+              <li key={namn} className="matrix-chip">
+                {namn}
+              </li>
+            ))}
+            {restAbroad > 0 && <li className="matrix-chip matrix-chip-more">+{restAbroad} fler</li>}
+          </ul>
+        </div>
+
+        <div className="matrix-card">
+          <h3 className="matrix-card-title">Utländskt ägt, ändå tillverkat i Sverige</h3>
+          <p className="matrix-card-text">
+            Bara {foreignHere.length} varumärken ägs från utlandet men tillverkas fortfarande här:
+          </p>
+          <ul className="matrix-owners">
+            {foreignHere.map((b) => (
+              <li key={b.namn} className="matrix-owner">
+                <span className="matrix-owner-name">{b.namn}</span>
+                <span className="matrix-owner-by">
+                  {b.ownerLand && <Flag countryCode={b.ownerLand} />}
+                  {b.owner}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1705,3 +1705,458 @@ body {
   font-weight: 600;
   color: #1a3050;
 }
+
+/* ========================================
+   Data Page (charts / statistics)
+   ======================================== */
+
+.data-section {
+  margin-bottom: 48px;
+}
+
+.data-section:last-child {
+  margin-bottom: 0;
+}
+
+.data-hero {
+  margin-bottom: 40px;
+}
+
+.data-section > p {
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 28px;
+  color: #525252;
+  margin-bottom: 24px;
+}
+
+/* Status donut */
+.status-donut {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 48px;
+}
+
+.status-donut-figure {
+  position: relative;
+  width: 240px;
+  height: 240px;
+  flex-shrink: 0;
+}
+
+.status-donut-svg {
+  width: 240px;
+  height: 240px;
+  display: block;
+}
+
+.status-donut-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.status-donut-total {
+  font-size: 48px;
+  font-weight: 700;
+  line-height: 1;
+  color: #1a3050;
+}
+
+.status-donut-total-label {
+  font-size: 14px;
+  font-weight: 400;
+  color: #6e6e6e;
+  margin-top: 4px;
+}
+
+.status-donut-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.status-donut-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-donut-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.status-donut-legend-label {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a3050;
+  min-width: 64px;
+}
+
+.status-donut-legend-value {
+  font-size: 18px;
+  font-weight: 400;
+  color: #525252;
+}
+
+.status-donut-legend-pct {
+  color: #6e6e6e;
+}
+
+/* Ownership bars */
+.ownership-bars {
+  max-width: 720px;
+}
+
+.ownership-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ownership-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 200px) 1fr;
+  align-items: center;
+  gap: 16px;
+}
+
+.ownership-name {
+  font-size: 15px;
+  font-weight: 400;
+  color: #1a3050;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ownership-track {
+  width: 100%;
+}
+
+.ownership-fill {
+  background-color: #1a3050;
+  height: 26px;
+  border-radius: 0 4px 4px 0;
+  min-width: 2.4em;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 8px;
+  box-sizing: border-box;
+}
+
+.ownership-count {
+  font-size: 13px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.ownership-caption {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  color: #6e6e6e;
+  margin-top: 20px;
+}
+
+.ownership-empty {
+  font-size: 16px;
+  color: #6e6e6e;
+}
+
+/* Country bars (manufacturing countries, foreign owners) */
+.country-bars {
+  max-width: 720px;
+}
+
+.country-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.country-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 220px) 1fr;
+  align-items: center;
+  gap: 16px;
+}
+
+.country-name {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.country-name-text {
+  font-size: 15px;
+  font-weight: 400;
+  color: #1a3050;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.country-flag-placeholder {
+  width: 16px;
+  flex-shrink: 0;
+}
+
+.country-name .flag-icon {
+  flex-shrink: 0;
+}
+
+.country-track {
+  width: 100%;
+}
+
+.country-fill {
+  background-color: #1a3050;
+  height: 26px;
+  border-radius: 0 4px 4px 0;
+  min-width: 2.4em;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 8px;
+  box-sizing: border-box;
+}
+
+.country-count {
+  font-size: 13px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+/* Swedishness matrix (owner nationality x manufacturing status) */
+.matrix {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  max-width: 760px;
+}
+
+.matrix-table-wrap {
+  overflow-x: auto;
+}
+
+.matrix-table {
+  border-collapse: separate;
+  border-spacing: 6px;
+  width: 100%;
+}
+
+.matrix-stub {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6e6e6e;
+  text-align: left;
+  vertical-align: bottom;
+  padding: 0 8px 6px 0;
+}
+
+.matrix-grouphead {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6e6e6e;
+  text-align: center;
+  padding-bottom: 6px;
+  letter-spacing: 0.02em;
+}
+
+.matrix-colhead {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a3050;
+  text-align: center;
+  padding-bottom: 6px;
+}
+
+.matrix-total-head {
+  vertical-align: bottom;
+  padding-left: 8px;
+}
+
+.matrix-rowhead {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a3050;
+  text-align: right;
+  white-space: nowrap;
+  padding-right: 8px;
+}
+
+.matrix-cell {
+  text-align: center;
+  border-radius: 6px;
+  min-width: 72px;
+  height: 64px;
+  vertical-align: middle;
+}
+
+.matrix-count {
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.matrix-total {
+  background-color: #f5f5f5;
+  color: #525252;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.matrix-grand {
+  color: #1a3050;
+}
+
+.matrix-highlights {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.matrix-card {
+  background-color: #ffffff;
+  border: 1px solid var(--border-light, #c6c6c6);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.matrix-card-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: #1a3050;
+  margin: 0 0 8px;
+}
+
+.matrix-card-text {
+  font-size: 14px;
+  line-height: 22px;
+  color: #525252;
+  margin: 0 0 14px;
+}
+
+.matrix-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.matrix-chip {
+  font-size: 13px;
+  font-weight: 400;
+  color: #1a3050;
+  background-color: #ededed;
+  border-radius: 999px;
+  padding: 5px 12px;
+}
+
+.matrix-chip-more {
+  background-color: transparent;
+  color: #6e6e6e;
+  font-style: italic;
+}
+
+.matrix-owners {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.matrix-owner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.matrix-owner-name {
+  font-weight: 600;
+  color: #1a3050;
+}
+
+.matrix-owner-by {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #6e6e6e;
+  text-align: right;
+}
+
+/* Mobile: data page */
+@media (max-width: 599px) {
+  .data-section {
+    margin-bottom: 32px;
+  }
+
+  .data-section > p {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  .status-donut {
+    gap: 24px;
+    justify-content: center;
+  }
+
+  .ownership-row {
+    grid-template-columns: minmax(90px, 130px) 1fr;
+    gap: 10px;
+  }
+
+  .ownership-name {
+    font-size: 13px;
+  }
+
+  .country-row {
+    grid-template-columns: minmax(100px, 150px) 1fr;
+    gap: 10px;
+  }
+
+  .country-name-text {
+    font-size: 13px;
+  }
+
+  .matrix-highlights {
+    grid-template-columns: 1fr;
+  }
+
+  .matrix-cell {
+    min-width: 56px;
+    height: 56px;
+  }
+
+  .matrix-count {
+    font-size: 20px;
+  }
+}

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -1,0 +1,117 @@
+/**
+ * Country helpers for the Data page charts.
+ *
+ * Two directions are needed:
+ *   - ISO code  -> Swedish name  (owner countries: koncern.agareLand is an ISO code)
+ *   - Swedish name -> ISO code   (manufacturing: tillverkningslander are Swedish names,
+ *                                 the Flag component needs an ISO code)
+ *
+ * Manufacturing data also carries some noise we normalize away:
+ *   "SE" (ISO instead of name), "Poland" (English), "Sverige (begränsat)" (qualifier).
+ */
+
+// ISO 3166-1 alpha-2 -> Swedish country name.
+export const ISO_TO_SV: Record<string, string> = {
+  SE: 'Sverige',
+  US: 'USA',
+  CN: 'Kina',
+  FI: 'Finland',
+  DE: 'Tyskland',
+  DK: 'Danmark',
+  NO: 'Norge',
+  NL: 'Nederländerna',
+  CH: 'Schweiz',
+  JP: 'Japan',
+  FR: 'Frankrike',
+  IT: 'Italien',
+  HK: 'Hongkong',
+  BH: 'Bahrain',
+  GB: 'Storbritannien',
+  ES: 'Spanien',
+  BE: 'Belgien',
+  AT: 'Österrike',
+  CA: 'Kanada',
+  PL: 'Polen',
+  PT: 'Portugal',
+};
+
+// Swedish country name -> ISO 3166-1 alpha-2 (for flags on the manufacturing chart).
+export const SV_TO_ISO: Record<string, string> = {
+  Sverige: 'SE',
+  USA: 'US',
+  Kina: 'CN',
+  Finland: 'FI',
+  Tyskland: 'DE',
+  Danmark: 'DK',
+  Norge: 'NO',
+  Nederländerna: 'NL',
+  Schweiz: 'CH',
+  Japan: 'JP',
+  Frankrike: 'FR',
+  Italien: 'IT',
+  Hongkong: 'HK',
+  Bahrain: 'BH',
+  Storbritannien: 'GB',
+  Spanien: 'ES',
+  Belgien: 'BE',
+  Österrike: 'AT',
+  Kanada: 'CA',
+  Polen: 'PL',
+  Portugal: 'PT',
+  Vietnam: 'VN',
+  Turkiet: 'TR',
+  Bangladesh: 'BD',
+  Indien: 'IN',
+  Estland: 'EE',
+  Brasilien: 'BR',
+  Taiwan: 'TW',
+  Rumänien: 'RO',
+  Tunisien: 'TN',
+  Thailand: 'TH',
+  Indonesien: 'ID',
+  Lettland: 'LV',
+  Litauen: 'LT',
+  Sydkorea: 'KR',
+  Slovakien: 'SK',
+  Slovenien: 'SI',
+  Irland: 'IE',
+  Ungern: 'HU',
+  Tjeckien: 'CZ',
+  Mexiko: 'MX',
+  'Sri Lanka': 'LK',
+  Myanmar: 'MM',
+  Kambodja: 'KH',
+  Nordmakedonien: 'MK',
+};
+
+// Vague/region labels that are not a single country. Collapsed into one bar.
+export const REGION_LABELS = new Set<string>([
+  'Europa',
+  'Asien',
+  'Afrika',
+  'Nordamerika',
+  'Sydamerika',
+  'Oceanien',
+  'Mellanöstern',
+  'Globalt',
+  'Världen',
+  'Internationellt',
+  'Utomlands',
+]);
+
+// Fix up known data-entry variants before matching against the maps above.
+const SYNONYMS: Record<string, string> = {
+  SE: 'Sverige',
+  Poland: 'Polen',
+  England: 'Storbritannien',
+  UK: 'Storbritannien',
+};
+
+/**
+ * Normalize a raw manufacturing-country string: trim, drop parenthetical
+ * qualifiers ("Sverige (begränsat)" -> "Sverige"), and map known variants.
+ */
+export function normalizeCountryName(raw: string): string {
+  const stripped = raw.replace(/\s*\([^)]*\)/g, '').trim();
+  return SYNONYMS[stripped] ?? stripped;
+}

--- a/src/pages/Data.tsx
+++ b/src/pages/Data.tsx
@@ -1,0 +1,228 @@
+import { useState, useMemo, useEffect } from 'react';
+import StatusDonut from '../components/StatusDonut';
+import SwedishnessMatrix from '../components/SwedishnessMatrix';
+import OwnershipBars, { OwnerCount } from '../components/OwnershipBars';
+import CountryBars, { CountryBar } from '../components/CountryBars';
+import { sanityClient } from '../lib/sanityClient';
+import { ALL_BRANDS_QUERY } from '../lib/queries';
+import { Brand } from '../types/brand';
+import { ISO_TO_SV, SV_TO_ISO, REGION_LABELS, normalizeCountryName } from '../lib/countries';
+
+// Swedish locale comparator for tie-breaking equal counts (matches Home.tsx).
+const compareSwedish = (a: string, b: string): number => {
+  return a.localeCompare(b, 'sv-SE', { sensitivity: 'base' });
+};
+
+export default function Data() {
+  const [allBrands, setAllBrands] = useState<Brand[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = 'Data & statistik - Svensk Databas';
+  }, []);
+
+  useEffect(() => {
+    sanityClient
+      .fetch<Brand[]>(ALL_BRANDS_QUERY)
+      .then((data) => {
+        setAllBrands(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch brands:', err);
+        setError('Kunde inte ladda varumärken. Försök igen senare.');
+        setLoading(false);
+      });
+  }, []);
+
+  const total = allBrands.length;
+
+  // Manufacturing-status split across all brands.
+  const statusCounts = useMemo(() => {
+    const counts = { Ja: 0, Delvis: 0, Nej: 0 };
+    for (const brand of allBrands) {
+      counts[brand.tillverkadISverige] += 1;
+    }
+    return counts;
+  }, [allBrands]);
+
+  // Ownership concentration: group by parent company (moderbolag), keep groups of >= 2.
+  // We group on moderbolag rather than the "ägare" (ultimate owner) field because ägare
+  // is free text that mixes real entities with ownership-type labels ("Privatägd",
+  // "Familjeägt", "Börsnoterat (...)") — grouping on it would merge unrelated companies.
+  const owners = useMemo<OwnerCount[]>(() => {
+    const byOwner = new Map<string, number>();
+    for (const brand of allBrands) {
+      const owner = brand.merInfo.moderbolag?.trim();
+      if (owner) {
+        byOwner.set(owner, (byOwner.get(owner) ?? 0) + 1);
+      }
+    }
+    return [...byOwner.entries()]
+      .map(([owner, count]) => ({ owner, count }))
+      .filter((o) => o.count >= 2)
+      .sort((a, b) => b.count - a.count || compareSwedish(a.owner, b.owner));
+  }, [allBrands]);
+
+  // Foreign owners: brands whose ultimate owner (koncern.ägareLand) is registered
+  // outside Sweden, grouped by owner country. ägareLand is an ISO code.
+  const ownerCountries = useMemo<CountryBar[]>(() => {
+    const byCode = new Map<string, number>();
+    for (const brand of allBrands) {
+      const ks = brand.merInfo.koncernstruktur;
+      if (typeof ks === 'string') continue; // legacy string format has no country
+      const code = ks.ägareLand?.trim().toUpperCase();
+      if (!code || code === 'SE') continue;
+      byCode.set(code, (byCode.get(code) ?? 0) + 1);
+    }
+    return [...byCode.entries()]
+      .map(([code, count]) => ({ code, label: ISO_TO_SV[code] ?? code, count }))
+      .sort((a, b) => b.count - a.count || compareSwedish(a.label, b.label));
+  }, [allBrands]);
+
+  const foreignOwnedCount = useMemo(
+    () => ownerCountries.reduce((sum, o) => sum + o.count, 0),
+    [ownerCountries]
+  );
+
+  // Most common manufacturing countries: count how many brands list each country.
+  // A brand manufacturing in several countries is counted once per country. Vague
+  // region labels (Europa, Asien, ...) collapse into one bar; single-brand countries
+  // collapse into an "Övriga länder" bar. Both aggregate bars sit at the bottom.
+  const manufacturingCountries = useMemo<CountryBar[]>(() => {
+    const byCountry = new Map<string, number>();
+    let regionCount = 0;
+    for (const brand of allBrands) {
+      const entries = brand.merInfo.tillverkningsländer;
+      if (!entries || entries.length === 0) continue;
+      const countries = new Set<string>();
+      let hasRegion = false;
+      for (const entry of entries) {
+        if (!entry) continue;
+        const name = normalizeCountryName(entry);
+        if (!name) continue;
+        if (REGION_LABELS.has(name)) hasRegion = true;
+        else countries.add(name);
+      }
+      for (const name of countries) {
+        byCountry.set(name, (byCountry.get(name) ?? 0) + 1);
+      }
+      if (hasRegion) regionCount += 1;
+    }
+
+    const all = [...byCountry.entries()].map(([label, count]) => ({
+      code: SV_TO_ISO[label],
+      label,
+      count,
+    }));
+    const multi = all
+      .filter((c) => c.count >= 2)
+      .sort((a, b) => b.count - a.count || compareSwedish(a.label, b.label));
+    const singles = all.filter((c) => c.count < 2);
+
+    const bars: CountryBar[] = [...multi];
+    if (singles.length > 0) {
+      const singleTotal = singles.reduce((sum, c) => sum + c.count, 0);
+      bars.push({ label: `Övriga länder (${singles.length} st)`, count: singleTotal });
+    }
+    if (regionCount > 0) {
+      bars.push({ label: 'Region ej specificerad', count: regionCount });
+    }
+    return bars;
+  }, [allBrands]);
+
+  if (loading) {
+    return (
+      <main className="main">
+        <div className="container">
+          <div className="content">
+            <div className="loading-state">Laddar data...</div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="main">
+        <div className="container">
+          <div className="content">
+            <div className="error-state">{error}</div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="main">
+      <div className="container">
+        <div className="content">
+          <section className="data-section data-hero">
+            <h1 className="about-title">Data & statistik</h1>
+            <p className="about-intro">
+              En överblick över hela databasen: hur stor andel av varumärkena som faktiskt
+              tillverkas i Sverige, var produktionen sker, vilka ägare som kontrollerar flest
+              varumärken och hur många som ägs från utlandet.
+            </p>
+          </section>
+
+          <section className="data-section">
+            <h2 className="about-heading">Tillverkad i Sverige</h2>
+            <p>Fördelningen av samtliga {total} varumärken i databasen.</p>
+            <StatusDonut counts={statusCounts} total={total} />
+          </section>
+
+          <section className="data-section">
+            <h2 className="about-heading">Namn mot verklighet</h2>
+            <p>
+              Hur svenskt ett varumärke känns handlar ofta om vem som äger det, men var det
+              faktiskt tillverkas är en annan sak. Matrisen korsar ägarnationalitet med
+              tillverkning i Sverige.
+            </p>
+            <SwedishnessMatrix brands={allBrands} />
+          </section>
+
+          <section className="data-section">
+            <h2 className="about-heading">Vanligaste tillverkningsländer</h2>
+            <p>Antal varumärken som anger respektive land som tillverkningsland.</p>
+            <CountryBars
+              items={manufacturingCountries}
+              caption={
+                <>
+                  Ett varumärke kan tillverka i flera länder och räknas då i varje land, därför
+                  summerar staplarna till mer än {total}. Länder med bara ett varumärke är samlade
+                  under Övriga länder.
+                </>
+              }
+              emptyMessage="Inga tillverkningsländer angivna i databasen."
+            />
+          </section>
+
+          <section className="data-section">
+            <h2 className="about-heading">Ägarkoncentration</h2>
+            <p>Antal varumärken per moderbolag — bolag som äger minst två varumärken i databasen.</p>
+            <OwnershipBars owners={owners} total={total} />
+          </section>
+
+          <section className="data-section">
+            <h2 className="about-heading">Utländska ägare</h2>
+            <p>Varumärken vars yttersta ägare är registrerad utanför Sverige, per ägarland.</p>
+            <CountryBars
+              items={ownerCountries}
+              caption={
+                <>
+                  {foreignOwnedCount} av {total} varumärken ägs av ett bolag registrerat utanför
+                  Sverige. Övriga ägs av svenska bolag eller är oberoende.
+                </>
+              }
+              emptyMessage="Inga utländskt ägda varumärken i databasen."
+            />
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new **Data & statistik** page (`/data`) that visualizes the whole database, turning the dataset into scannable insights about "Made in Sweden" reality.

## Sections

- **Tillverkad i Sverige** (donut): manufacturing-status split across all brands.
- **Namn mot verklighet** (Swedishness matrix): a 2x3 contingency table crossing owner nationality (Svenskägt / Utländskt ägt) with manufacturing status (Ja / Delvis / Nej). Cells are heatmap-tinted in the status palette. Two insight cards below highlight the surprise quadrants: 45 Swedish-owned brands made abroad, and the 7 foreign-owned brands still made in Sweden (Absolut, Marabou, Hästens, Zoégas, Pripps, Felix, L:A Bruket).
- **Vanligaste tillverkningsländer**: how many brands list each country as a manufacturing location, with flags. Single-brand countries collapse into "Övriga länder" and vague labels (Europa, Asien, ...) into "Region ej specificerad".
- **Ägarkoncentration**: brands per parent company (moderbolag).
- **Utländska ägare**: the 32 foreign-owned brands grouped by owner country.

## Implementation

- New components: `StatusDonut`, `OwnershipBars`, `CountryBars` (reused for two sections), `SwedishnessMatrix`.
- New `src/lib/countries.ts`: ISO/Swedish name maps, region-label set, and `normalizeCountryName()` which cleans data noise ("SE", "Poland", "Sverige (begränsat)").
- All aggregations computed from the existing `ALL_BRANDS_QUERY` fetch, no GROQ or schema changes.
- Reuses the site's reserved status color palette and existing `Flag` component.

## Verification

- `npm run build` passes (TypeScript compile clean).
- Matrix bucket counts validated against Sanity: totals reconcile to 133 brands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)